### PR TITLE
Feat/bc 360/32/whiteboard performance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,22 @@ Supported Angular version: `16`.
 npm install ngx-konva konva
 ```
 
+Simply import `NgxKonvaModule` inside any module you need to use it in:
+
+```typescript
+import { NgxKonvaModule } from 'ngx-konva';
+
+@NgModule({
+  // ... your stuff
+  imports: [
+    // ... other modules import
+    NgxKonvaModule,
+  ],
+  // ... other module stuff
+})
+export class MyModule { }
+```
+
 ## Konva API implementation status
 
 | API                                                                          | Status | Component                                                                     |

--- a/docs/classes/KoDragDirective.md
+++ b/docs/classes/KoDragDirective.md
@@ -50,7 +50,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:25](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L25)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:30](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L30)
 
 ## Properties
 
@@ -60,7 +60,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:17](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L17)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L22)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:14](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L14)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L19)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:11](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L11)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:16](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L16)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:19](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L19)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:24](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L24)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:22](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L22)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:27](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L27)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:23](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L23)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L28)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L21)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:26](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L26)
 
 ## Methods
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:46](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L46)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:51](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L51)
 
 ___
 
@@ -194,7 +194,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:39](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L39)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:44](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L44)
 
 ___
 
@@ -212,7 +212,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:36](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L36)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:41](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L41)
 
 ___
 
@@ -232,7 +232,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:56](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L56)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:61](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L61)
 
 ___
 
@@ -252,7 +252,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:60](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L60)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:65](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L65)
 
 ___
 
@@ -272,4 +272,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:52](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L52)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:57](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L57)

--- a/docs/classes/KoGroupComponent.md
+++ b/docs/classes/KoGroupComponent.md
@@ -26,8 +26,10 @@
 - [\_tweenTimeout](KoGroupComponent.md#_tweentimeout)
 - [afterUpdate](KoGroupComponent.md#afterupdate)
 - [beforeUpdate](KoGroupComponent.md#beforeupdate)
+- [configDefaults](KoGroupComponent.md#configdefaults)
 - [group](KoGroupComponent.md#group)
 - [id](KoGroupComponent.md#id)
+- [koListening](KoGroupComponent.md#kolistening)
 - [layerComponent](KoGroupComponent.md#layercomponent)
 - [onNewItem](KoGroupComponent.md#onnewitem)
 - [sub](KoGroupComponent.md#sub)
@@ -40,6 +42,7 @@
 ### Accessors
 
 - [config](KoGroupComponent.md#config)
+- [shouldListen](KoGroupComponent.md#shouldlisten)
 
 ### Methods
 
@@ -55,12 +58,13 @@
 
 ### constructor
 
-• **new KoGroupComponent**(`layerComponent`): [`KoGroupComponent`](KoGroupComponent.md)
+• **new KoGroupComponent**(`koListening`, `layerComponent`): [`KoGroupComponent`](KoGroupComponent.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
+| `koListening` | `KoListeningDirective` |
 | `layerComponent` | [`KoLayerComponent`](KoLayerComponent.md) |
 
 #### Returns
@@ -73,7 +77,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:39](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L39)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:39](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L39)
 
 ## Properties
 
@@ -83,7 +87,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:20](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L20)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:23](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L23)
 
 ___
 
@@ -97,7 +101,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L38)
 
 ___
 
@@ -111,7 +115,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:39](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L39)
 
 ___
 
@@ -121,7 +125,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:37](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L37)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:37](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L37)
 
 ___
 
@@ -131,7 +135,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:34](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L34)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:34](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L34)
+
+___
+
+### configDefaults
+
+• `Protected` **configDefaults**: [`KoShapeConfig`](../modules.md#koshapeconfig)
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[configDefaults](KoNestable.md#configdefaults)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:46](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L46)
 
 ___
 
@@ -141,7 +159,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L18)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:21](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L21)
 
 ___
 
@@ -155,7 +173,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L22)
+
+___
+
+### koListening
+
+• **koListening**: `KoListeningDirective`
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[koListening](KoNestable.md#kolistening)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:40](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L40)
 
 ___
 
@@ -165,7 +197,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:40](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L40)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:41](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L41)
 
 ___
 
@@ -175,7 +207,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:31](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L31)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L31)
 
 ___
 
@@ -189,7 +221,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:36](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L36)
 
 ___
 
@@ -203,7 +235,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L28)
 
 ___
 
@@ -217,7 +249,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -231,7 +263,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
 
 ___
 
@@ -245,7 +277,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L25)
 
 ___
 
@@ -280,7 +312,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L19)
 
 ## Accessors
 
@@ -300,7 +332,25 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L24)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L25)
+
+___
+
+### shouldListen
+
+• `get` **shouldListen**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+KoNestable.shouldListen
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
 
 ## Methods
 
@@ -320,7 +370,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:64](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L64)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:65](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L65)
 
 ___
 
@@ -338,7 +388,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:54](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L54)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:55](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L55)
 
 ___
 
@@ -356,7 +406,7 @@ AfterViewInit.ngAfterViewInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:51](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L51)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:52](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L52)
 
 ___
 
@@ -374,7 +424,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:44](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L44)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:64](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L64)
 
 ___
 
@@ -396,7 +446,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:47](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L47)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:48](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L48)
 
 ___
 
@@ -420,7 +470,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L76)
 
 ___
 
@@ -434,4 +484,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:58](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-group.component.ts#L58)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:59](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-group.component.ts#L59)

--- a/docs/classes/KoHoverDirective.md
+++ b/docs/classes/KoHoverDirective.md
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:23](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L23)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L28)
 
 ## Properties
 
@@ -58,7 +58,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:16](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L16)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:21](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L21)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:14](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L14)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L19)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:11](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L11)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:16](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L16)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L18)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:23](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L23)
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:20](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L20)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L25)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L21)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:26](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L26)
 
 ## Methods
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:43](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L43)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:48](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L48)
 
 ___
 
@@ -156,7 +156,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:37](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L37)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:42](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L42)
 
 ___
 
@@ -174,7 +174,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:34](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L34)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:39](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L39)
 
 ___
 
@@ -188,7 +188,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:48](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L48)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:53](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L53)
 
 ___
 
@@ -202,4 +202,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:53](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L53)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:58](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L58)

--- a/docs/classes/KoImageComponent.md
+++ b/docs/classes/KoImageComponent.md
@@ -28,8 +28,10 @@
 - [afterUpdate](KoImageComponent.md#afterupdate)
 - [beforeUpdate](KoImageComponent.md#beforeupdate)
 - [centerOrigin](KoImageComponent.md#centerorigin)
+- [configDefaults](KoImageComponent.md#configdefaults)
 - [groupComponent](KoImageComponent.md#groupcomponent)
 - [id](KoImageComponent.md#id)
+- [koListening](KoImageComponent.md#kolistening)
 - [layerComponent](KoImageComponent.md#layercomponent)
 - [node](KoImageComponent.md#node)
 - [onLoadListener](KoImageComponent.md#onloadlistener)
@@ -43,6 +45,7 @@
 ### Accessors
 
 - [config](KoImageComponent.md#config)
+- [shouldListen](KoImageComponent.md#shouldlisten)
 - [src](KoImageComponent.md#src)
 
 ### Methods
@@ -60,12 +63,13 @@
 
 ### constructor
 
-• **new KoImageComponent**(`layerComponent`, `groupComponent`): [`KoImageComponent`](KoImageComponent.md)
+• **new KoImageComponent**(`koListening`, `layerComponent`, `groupComponent`): [`KoImageComponent`](KoImageComponent.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
+| `koListening` | `KoListeningDirective` |
 | `layerComponent` | [`KoLayerComponent`](KoLayerComponent.md) |
 | `groupComponent` | [`KoGroupComponent`](KoGroupComponent.md) |
 
@@ -79,7 +83,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:61](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L61)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:57](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L57)
 
 ## Properties
 
@@ -89,7 +93,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:36](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L36)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L38)
 
 ___
 
@@ -99,7 +103,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:23](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L23)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L25)
 
 ___
 
@@ -109,7 +113,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:25](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L25)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:27](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L27)
 
 ___
 
@@ -123,7 +127,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L38)
 
 ___
 
@@ -137,7 +141,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:39](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L39)
 
 ___
 
@@ -147,7 +151,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:57](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L57)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:53](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L53)
 
 ___
 
@@ -157,7 +161,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:54](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L54)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:50](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L50)
 
 ___
 
@@ -167,7 +171,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:51](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L51)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:47](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L47)
+
+___
+
+### configDefaults
+
+• `Protected` **configDefaults**: [`KoShapeConfig`](../modules.md#koshapeconfig)
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[configDefaults](KoNestable.md#configdefaults)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:46](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L46)
 
 ___
 
@@ -177,7 +195,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:63](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L63)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:60](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L60)
 
 ___
 
@@ -191,7 +209,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L22)
+
+___
+
+### koListening
+
+• **koListening**: `KoListeningDirective`
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[koListening](KoNestable.md#kolistening)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:58](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L58)
 
 ___
 
@@ -201,7 +233,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:62](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L62)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:59](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L59)
 
 ___
 
@@ -211,7 +243,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L21)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:23](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L23)
 
 ___
 
@@ -229,7 +261,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:59](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L59)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:55](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L55)
 
 ___
 
@@ -243,7 +275,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:36](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L36)
 
 ___
 
@@ -257,7 +289,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L28)
 
 ___
 
@@ -271,7 +303,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -285,7 +317,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
 
 ___
 
@@ -299,7 +331,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L25)
 
 ___
 
@@ -334,7 +366,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L19)
 
 ## Accessors
 
@@ -354,7 +386,25 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:40](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L40)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:40](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L40)
+
+___
+
+### shouldListen
+
+• `get` **shouldListen**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+KoNestable.shouldListen
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
 
 ___
 
@@ -374,7 +424,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L27)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:29](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L29)
 
 ## Methods
 
@@ -388,7 +438,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:99](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L99)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:96](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L96)
 
 ___
 
@@ -402,7 +452,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:95](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L95)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:92](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L92)
 
 ___
 
@@ -420,7 +470,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:83](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L83)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:80](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L80)
 
 ___
 
@@ -438,7 +488,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:78](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L78)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:75](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L75)
 
 ___
 
@@ -460,7 +510,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:62](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L62)
 
 ___
 
@@ -474,7 +524,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:108](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L108)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:105](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L105)
 
 ___
 
@@ -498,7 +548,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L76)
 
 ___
 
@@ -512,4 +562,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:87](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L87)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:84](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L84)

--- a/docs/classes/KoLabelComponent.md
+++ b/docs/classes/KoLabelComponent.md
@@ -28,8 +28,10 @@
 - [afterUpdate](KoLabelComponent.md#afterupdate)
 - [beforeUpdate](KoLabelComponent.md#beforeupdate)
 - [centerOrigin](KoLabelComponent.md#centerorigin)
+- [configDefaults](KoLabelComponent.md#configdefaults)
 - [groupComponent](KoLabelComponent.md#groupcomponent)
 - [id](KoLabelComponent.md#id)
+- [koListening](KoLabelComponent.md#kolistening)
 - [layerComponent](KoLabelComponent.md#layercomponent)
 - [node](KoLabelComponent.md#node)
 - [sub](KoLabelComponent.md#sub)
@@ -44,6 +46,7 @@
 ### Accessors
 
 - [config](KoLabelComponent.md#config)
+- [shouldListen](KoLabelComponent.md#shouldlisten)
 - [tagConfig](KoLabelComponent.md#tagconfig)
 - [tagDisabled](KoLabelComponent.md#tagdisabled)
 - [textConfig](KoLabelComponent.md#textconfig)
@@ -65,12 +68,13 @@
 
 ### constructor
 
-• **new KoLabelComponent**(`layerComponent`, `groupComponent`): [`KoLabelComponent`](KoLabelComponent.md)
+• **new KoLabelComponent**(`koListening`, `layerComponent`, `groupComponent`): [`KoLabelComponent`](KoLabelComponent.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
+| `koListening` | `KoListeningDirective` |
 | `layerComponent` | [`KoLayerComponent`](KoLayerComponent.md) |
 | `groupComponent` | [`KoGroupComponent`](KoGroupComponent.md) |
 
@@ -84,7 +88,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:76](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L76)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L76)
 
 ## Properties
 
@@ -94,7 +98,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:23](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L23)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:26](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L26)
 
 ___
 
@@ -104,7 +108,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:41](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L41)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:41](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L41)
 
 ___
 
@@ -114,7 +118,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:33](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L33)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:33](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L33)
 
 ___
 
@@ -128,7 +132,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L38)
 
 ___
 
@@ -142,7 +146,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:39](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L39)
 
 ___
 
@@ -152,7 +156,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:74](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L74)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:74](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L74)
 
 ___
 
@@ -162,7 +166,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:71](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L71)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:71](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L71)
 
 ___
 
@@ -172,7 +176,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:68](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L68)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:68](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L68)
+
+___
+
+### configDefaults
+
+• `Protected` **configDefaults**: [`KoShapeConfig`](../modules.md#koshapeconfig)
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[configDefaults](KoNestable.md#configdefaults)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:46](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L46)
 
 ___
 
@@ -182,7 +200,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:78](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L78)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:79](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L79)
 
 ___
 
@@ -196,7 +214,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L22)
+
+___
+
+### koListening
+
+• **koListening**: `KoListeningDirective`
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[koListening](KoNestable.md#kolistening)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:77](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L77)
 
 ___
 
@@ -206,7 +238,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:77](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L77)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:78](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L78)
 
 ___
 
@@ -216,7 +248,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:19](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L19)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L22)
 
 ___
 
@@ -230,7 +262,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:36](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L36)
 
 ___
 
@@ -240,7 +272,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L21)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L24)
 
 ___
 
@@ -250,7 +282,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:20](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L20)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:23](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L23)
 
 ___
 
@@ -264,7 +296,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L28)
 
 ___
 
@@ -278,7 +310,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -292,7 +324,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
 
 ___
 
@@ -306,7 +338,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L25)
 
 ___
 
@@ -341,7 +373,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L19)
 
 ## Accessors
 
@@ -361,7 +393,25 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L27)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L28)
+
+___
+
+### shouldListen
+
+• `get` **shouldListen**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+KoNestable.shouldListen
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
 
 ___
 
@@ -381,7 +431,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:43](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L43)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:43](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L43)
 
 ___
 
@@ -401,7 +451,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:50](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L50)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:50](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L50)
 
 ___
 
@@ -421,7 +471,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L35)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:35](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L35)
 
 ___
 
@@ -441,7 +491,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:59](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L59)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:59](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L59)
 
 ## Methods
 
@@ -455,7 +505,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:130](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L130)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:131](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L131)
 
 ___
 
@@ -469,7 +519,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:126](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L126)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:127](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L127)
 
 ___
 
@@ -487,7 +537,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:100](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L100)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:101](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L101)
 
 ___
 
@@ -505,7 +555,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:96](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L96)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:97](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L97)
 
 ___
 
@@ -527,7 +577,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:62](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L62)
 
 ___
 
@@ -551,7 +601,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L76)
 
 ___
 
@@ -565,7 +615,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:112](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L112)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:113](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L113)
 
 ___
 
@@ -579,7 +629,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:118](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L118)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:119](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L119)
 
 ___
 
@@ -593,4 +643,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:104](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-label.component.ts#L104)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:105](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-label.component.ts#L105)

--- a/docs/classes/KoLayerComponent.md
+++ b/docs/classes/KoLayerComponent.md
@@ -27,7 +27,10 @@
 - [\_tweenTimeout](KoLayerComponent.md#_tweentimeout)
 - [afterUpdate](KoLayerComponent.md#afterupdate)
 - [beforeUpdate](KoLayerComponent.md#beforeupdate)
+- [configDefaults](KoLayerComponent.md#configdefaults)
+- [draw$](KoLayerComponent.md#draw$)
 - [id](KoLayerComponent.md#id)
+- [koListening](KoLayerComponent.md#kolistening)
 - [layer](KoLayerComponent.md#layer)
 - [layerComponent](KoLayerComponent.md#layercomponent)
 - [onNewItem](KoLayerComponent.md#onnewitem)
@@ -42,10 +45,12 @@
 ### Accessors
 
 - [config](KoLayerComponent.md#config)
+- [shouldListen](KoLayerComponent.md#shouldlisten)
 
 ### Methods
 
 - [addChild](KoLayerComponent.md#addchild)
+- [draw](KoLayerComponent.md#draw)
 - [getKoItem](KoLayerComponent.md#getkoitem)
 - [ngAfterViewInit](KoLayerComponent.md#ngafterviewinit)
 - [ngOnDestroy](KoLayerComponent.md#ngondestroy)
@@ -57,12 +62,13 @@
 
 ### constructor
 
-• **new KoLayerComponent**(`stageComponent?`, `stageAutoComponent?`, `layerComponent?`): [`KoLayerComponent`](KoLayerComponent.md)
+• **new KoLayerComponent**(`koListening`, `stageComponent?`, `stageAutoComponent?`, `layerComponent?`): [`KoLayerComponent`](KoLayerComponent.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
+| `koListening` | `KoListeningDirective` |
 | `stageComponent?` | [`KoStageComponent`](KoStageComponent.md) |
 | `stageAutoComponent?` | [`KoStageAutoScaleComponent`](KoStageAutoScaleComponent.md) |
 | `layerComponent?` | [`KoLayerComponent`](KoLayerComponent.md) |
@@ -77,7 +83,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:43](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L43)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:49](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L49)
 
 ## Properties
 
@@ -87,7 +93,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:23](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L23)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L28)
 
 ___
 
@@ -101,7 +107,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L38)
 
 ___
 
@@ -115,7 +121,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:39](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L39)
 
 ___
 
@@ -125,7 +131,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:41](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L41)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:47](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L47)
 
 ___
 
@@ -135,7 +141,31 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:38](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L38)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:44](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L44)
+
+___
+
+### configDefaults
+
+• `Protected` **configDefaults**: [`KoShapeConfig`](../modules.md#koshapeconfig)
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[configDefaults](KoNestable.md#configdefaults)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:46](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L46)
+
+___
+
+### draw$
+
+• `Private` **draw$**: `Subject`\<`void`\>
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:27](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L27)
 
 ___
 
@@ -149,7 +179,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L22)
+
+___
+
+### koListening
+
+• **koListening**: `KoListeningDirective`
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[koListening](KoNestable.md#kolistening)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:50](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L50)
 
 ___
 
@@ -159,7 +203,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:20](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L20)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L24)
 
 ___
 
@@ -169,7 +213,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:46](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L46)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:53](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L53)
 
 ___
 
@@ -179,7 +223,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L35)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:41](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L41)
 
 ___
 
@@ -189,7 +233,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L21)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L25)
 
 ___
 
@@ -203,7 +247,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:36](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L36)
 
 ___
 
@@ -217,7 +261,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L28)
 
 ___
 
@@ -231,7 +275,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -245,7 +289,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
 
 ___
 
@@ -259,7 +303,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L25)
 
 ___
 
@@ -294,7 +338,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L19)
 
 ## Accessors
 
@@ -314,7 +358,25 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:28](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L28)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L31)
+
+___
+
+### shouldListen
+
+• `get` **shouldListen**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+KoNestable.shouldListen
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
 
 ## Methods
 
@@ -334,7 +396,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:81](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L81)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:94](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L94)
+
+___
+
+### draw
+
+▸ **draw**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:106](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L106)
 
 ___
 
@@ -352,7 +428,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:70](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L70)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:83](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L83)
 
 ___
 
@@ -370,7 +446,7 @@ AfterViewInit.ngAfterViewInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:67](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L67)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:80](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L80)
 
 ___
 
@@ -392,7 +468,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:44](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L44)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:64](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L64)
 
 ___
 
@@ -414,7 +490,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:63](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L63)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L76)
 
 ___
 
@@ -438,7 +514,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L76)
 
 ___
 
@@ -452,4 +528,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:74](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L74)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:87](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L87)

--- a/docs/classes/KoMouseDirective.md
+++ b/docs/classes/KoMouseDirective.md
@@ -74,7 +74,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:58](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L58)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:63](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L63)
 
 ## Properties
 
@@ -84,7 +84,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:42](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L42)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:47](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L47)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:36](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L36)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:41](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L41)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:39](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L39)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:44](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L44)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:12](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L12)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:17](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L17)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L27)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:32](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L32)
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L21)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:26](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L26)
 
 ___
 
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L15)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:20](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L20)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:33](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L33)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L38)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L24)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:29](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L29)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L18)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:23](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L23)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:30](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L30)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:35](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L35)
 
 ___
 
@@ -194,7 +194,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:44](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L44)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:49](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L49)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:54](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L54)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:59](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L59)
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:55](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L55)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:60](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L60)
 
 ___
 
@@ -266,7 +266,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:46](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L46)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:51](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L51)
 
 ___
 
@@ -290,7 +290,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:51](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L51)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:56](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L56)
 
 ___
 
@@ -314,7 +314,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:49](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L49)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:54](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L54)
 
 ___
 
@@ -338,7 +338,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:47](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L47)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:52](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L52)
 
 ___
 
@@ -362,7 +362,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:52](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L52)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:57](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L57)
 
 ___
 
@@ -386,7 +386,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:50](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L50)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:55](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L55)
 
 ___
 
@@ -410,7 +410,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:48](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L48)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:53](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L53)
 
 ___
 
@@ -434,7 +434,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:53](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L53)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:58](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L58)
 
 ___
 
@@ -444,7 +444,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:41](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L41)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:46](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L46)
 
 ## Methods
 
@@ -458,7 +458,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:92](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L92)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:97](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L97)
 
 ___
 
@@ -476,7 +476,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:74](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L74)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:79](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L79)
 
 ___
 
@@ -494,7 +494,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:71](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L71)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L76)
 
 ___
 
@@ -514,7 +514,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:141](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L141)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:146](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L146)
 
 ___
 
@@ -534,7 +534,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:145](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L145)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:150](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L150)
 
 ___
 
@@ -554,7 +554,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:113](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L113)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:118](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L118)
 
 ___
 
@@ -574,7 +574,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:129](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L129)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:134](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L134)
 
 ___
 
@@ -594,7 +594,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:137](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L137)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:142](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L142)
 
 ___
 
@@ -614,7 +614,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:117](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L117)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:122](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L122)
 
 ___
 
@@ -634,7 +634,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:133](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L133)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:138](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L138)
 
 ___
 
@@ -654,7 +654,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:125](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L125)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:130](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L130)
 
 ___
 
@@ -674,7 +674,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:121](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L121)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:126](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L126)
 
 ___
 
@@ -694,4 +694,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:109](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L109)
+[projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts:114](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts#L114)

--- a/docs/classes/KoNestable.md
+++ b/docs/classes/KoNestable.md
@@ -32,13 +32,19 @@
 - [\_initialSetConfig](KoNestable.md#_initialsetconfig)
 - [\_tween](KoNestable.md#_tween)
 - [\_tweenTimeout](KoNestable.md#_tweentimeout)
+- [configDefaults](KoNestable.md#configdefaults)
 - [id](KoNestable.md#id)
+- [koListening](KoNestable.md#kolistening)
 - [sub](KoNestable.md#sub)
 - [transitionDelay](KoNestable.md#transitiondelay)
 - [transitionOnFinish](KoNestable.md#transitiononfinish)
 - [transitionOnUpdate](KoNestable.md#transitiononupdate)
 - [transitionWith](KoNestable.md#transitionwith)
 - [Easings](KoNestable.md#easings)
+
+### Accessors
+
+- [shouldListen](KoNestable.md#shouldlisten)
 
 ### Methods
 
@@ -51,11 +57,21 @@
 
 ### constructor
 
-• **new KoNestable**(): [`KoNestable`](KoNestable.md)
+• **new KoNestable**(`koListening`): [`KoNestable`](KoNestable.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `koListening` | `KoListeningDirective` |
 
 #### Returns
 
 [`KoNestable`](KoNestable.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:58](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L58)
 
 ## Properties
 
@@ -65,7 +81,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:36](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L36)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:40](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L40)
 
 ___
 
@@ -75,7 +91,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L38)
 
 ___
 
@@ -85,7 +101,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:39](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L39)
+
+___
+
+### configDefaults
+
+• `Protected` **configDefaults**: [`KoShapeConfig`](../modules.md#koshapeconfig)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:46](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L46)
 
 ___
 
@@ -95,7 +121,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L22)
+
+___
+
+### koListening
+
+• `Protected` **koListening**: `KoListeningDirective`
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:59](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L59)
 
 ___
 
@@ -105,7 +141,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:36](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L36)
 
 ___
 
@@ -115,7 +151,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L28)
 
 ___
 
@@ -125,7 +161,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -135,7 +171,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
 
 ___
 
@@ -145,7 +181,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L25)
 
 ___
 
@@ -176,7 +212,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L19)
+
+## Accessors
+
+### shouldListen
+
+• `get` **shouldListen**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
 
 ## Methods
 
@@ -190,7 +240,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:38](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L38)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:54](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L54)
 
 ___
 
@@ -208,7 +258,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:44](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L44)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:64](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L64)
 
 ___
 
@@ -226,7 +276,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:62](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L62)
 
 ___
 
@@ -246,4 +296,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L76)

--- a/docs/classes/KoPointerDirective.md
+++ b/docs/classes/KoPointerDirective.md
@@ -74,7 +74,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:58](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L58)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:63](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L63)
 
 ## Properties
 
@@ -84,7 +84,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:42](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L42)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:47](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L47)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L21)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:26](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L26)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:36](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L36)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:41](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L41)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:39](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L39)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:44](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L44)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:12](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L12)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:17](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L17)
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L27)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:32](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L32)
 
 ___
 
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:33](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L33)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L38)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L15)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:20](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L20)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:30](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L30)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:35](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L35)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L24)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:29](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L29)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L18)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:23](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L23)
 
 ___
 
@@ -194,7 +194,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:44](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L44)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:49](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L49)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:49](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L49)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:54](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L54)
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:54](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L54)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:59](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L59)
 
 ___
 
@@ -266,7 +266,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:55](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L55)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:60](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L60)
 
 ___
 
@@ -290,7 +290,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:46](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L46)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:51](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L51)
 
 ___
 
@@ -314,7 +314,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:51](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L51)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:56](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L56)
 
 ___
 
@@ -338,7 +338,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:53](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L53)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:58](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L58)
 
 ___
 
@@ -362,7 +362,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:47](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L47)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:52](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L52)
 
 ___
 
@@ -386,7 +386,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:52](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L52)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:57](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L57)
 
 ___
 
@@ -410,7 +410,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:50](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L50)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:55](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L55)
 
 ___
 
@@ -434,7 +434,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:48](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L48)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:53](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L53)
 
 ___
 
@@ -444,7 +444,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:41](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L41)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:46](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L46)
 
 ## Methods
 
@@ -458,7 +458,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:92](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L92)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:97](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L97)
 
 ___
 
@@ -476,7 +476,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:74](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L74)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:79](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L79)
 
 ___
 
@@ -494,7 +494,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:71](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L71)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L76)
 
 ___
 
@@ -514,7 +514,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:121](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L121)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:126](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L126)
 
 ___
 
@@ -534,7 +534,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:141](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L141)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:146](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L146)
 
 ___
 
@@ -554,7 +554,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:145](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L145)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:150](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L150)
 
 ___
 
@@ -574,7 +574,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:109](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L109)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:114](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L114)
 
 ___
 
@@ -594,7 +594,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:129](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L129)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:134](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L134)
 
 ___
 
@@ -614,7 +614,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:137](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L137)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:142](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L142)
 
 ___
 
@@ -634,7 +634,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:113](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L113)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:118](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L118)
 
 ___
 
@@ -654,7 +654,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:133](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L133)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:138](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L138)
 
 ___
 
@@ -674,7 +674,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:125](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L125)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:130](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L130)
 
 ___
 
@@ -694,4 +694,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:117](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L117)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:122](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L122)

--- a/docs/classes/KoShapeComponent.md
+++ b/docs/classes/KoShapeComponent.md
@@ -26,9 +26,11 @@
 - [afterUpdate](KoShapeComponent.md#afterupdate)
 - [beforeUpdate](KoShapeComponent.md#beforeupdate)
 - [centerOrigin](KoShapeComponent.md#centerorigin)
+- [configDefaults](KoShapeComponent.md#configdefaults)
 - [elementRef](KoShapeComponent.md#elementref)
 - [groupComponent](KoShapeComponent.md#groupcomponent)
 - [id](KoShapeComponent.md#id)
+- [koListening](KoShapeComponent.md#kolistening)
 - [layerComponent](KoShapeComponent.md#layercomponent)
 - [selector](KoShapeComponent.md#selector)
 - [shape](KoShapeComponent.md#shape)
@@ -42,6 +44,7 @@
 ### Accessors
 
 - [config](KoShapeComponent.md#config)
+- [shouldListen](KoShapeComponent.md#shouldlisten)
 
 ### Methods
 
@@ -57,12 +60,13 @@
 
 ### constructor
 
-• **new KoShapeComponent**(`elementRef`, `layerComponent`, `groupComponent`): [`KoShapeComponent`](KoShapeComponent.md)
+• **new KoShapeComponent**(`koListening`, `elementRef`, `layerComponent`, `groupComponent`): [`KoShapeComponent`](KoShapeComponent.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
+| `koListening` | `KoListeningDirective` |
 | `elementRef` | `ElementRef`\<`HTMLElement`\> |
 | `layerComponent` | [`KoLayerComponent`](KoLayerComponent.md) |
 | `groupComponent` | [`KoGroupComponent`](KoGroupComponent.md) |
@@ -77,7 +81,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:45](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L45)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:40](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L40)
 
 ## Properties
 
@@ -87,7 +91,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:20](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L20)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L22)
 
 ___
 
@@ -101,7 +105,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L38)
 
 ___
 
@@ -115,7 +119,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:39](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L39)
 
 ___
 
@@ -125,7 +129,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:41](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L41)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:36](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L36)
 
 ___
 
@@ -135,7 +139,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:38](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L38)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:33](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L33)
 
 ___
 
@@ -145,7 +149,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L35)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:30](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L30)
+
+___
+
+### configDefaults
+
+• `Protected` **configDefaults**: [`KoShapeConfig`](../modules.md#koshapeconfig)
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[configDefaults](KoNestable.md#configdefaults)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:46](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L46)
 
 ___
 
@@ -155,7 +173,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:46](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L46)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:42](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L42)
 
 ___
 
@@ -165,7 +183,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:48](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L48)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:44](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L44)
 
 ___
 
@@ -179,7 +197,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L22)
+
+___
+
+### koListening
+
+• **koListening**: `KoListeningDirective`
+
+#### Inherited from
+
+[KoNestable](KoNestable.md).[koListening](KoNestable.md#kolistening)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:41](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L41)
 
 ___
 
@@ -189,7 +221,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:47](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L47)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:43](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L43)
 
 ___
 
@@ -199,7 +231,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:43](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L43)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L38)
 
 ___
 
@@ -209,7 +241,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L18)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:20](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L20)
 
 ___
 
@@ -223,7 +255,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:36](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L36)
 
 ___
 
@@ -237,7 +269,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L28)
 
 ___
 
@@ -251,7 +283,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -265,7 +297,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
 
 ___
 
@@ -279,7 +311,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:25](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L25)
 
 ___
 
@@ -314,7 +346,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L19)
 
 ## Accessors
 
@@ -334,7 +366,25 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L24)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L24)
+
+___
+
+### shouldListen
+
+• `get` **shouldListen**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+KoNestable.shouldListen
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
 
 ## Methods
 
@@ -348,7 +398,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:78](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L78)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:74](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L74)
 
 ___
 
@@ -362,7 +412,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:74](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L74)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:70](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L70)
 
 ___
 
@@ -380,7 +430,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:64](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L64)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:60](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L60)
 
 ___
 
@@ -398,7 +448,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:44](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L44)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:64](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L64)
 
 ___
 
@@ -420,7 +470,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:60](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L60)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:56](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L56)
 
 ___
 
@@ -444,7 +494,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:76](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L76)
 
 ___
 
@@ -458,4 +508,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:68](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L68)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:64](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L64)

--- a/docs/classes/KoStageAutoScaleComponent.md
+++ b/docs/classes/KoStageAutoScaleComponent.md
@@ -42,6 +42,7 @@
 ### Methods
 
 - [addChild](KoStageAutoScaleComponent.md#addchild)
+- [draw](KoStageAutoScaleComponent.md#draw)
 - [ngAfterContentInit](KoStageAutoScaleComponent.md#ngaftercontentinit)
 - [ngAfterViewInit](KoStageAutoScaleComponent.md#ngafterviewinit)
 - [ngOnDestroy](KoStageAutoScaleComponent.md#ngondestroy)
@@ -72,7 +73,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:30](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L30)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L31)
 
 ## Properties
 
@@ -82,7 +83,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:17](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L17)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:18](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L18)
 
 ___
 
@@ -96,7 +97,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L21)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L24)
 
 ___
 
@@ -110,7 +111,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L18)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:21](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L21)
 
 ___
 
@@ -120,7 +121,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:32](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L32)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:33](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L33)
 
 ___
 
@@ -134,7 +135,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:14](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L14)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:15](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L15)
 
 ___
 
@@ -144,7 +145,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:28](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L28)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:29](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L29)
 
 ___
 
@@ -154,7 +155,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:14](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L14)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:15](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L15)
 
 ___
 
@@ -168,7 +169,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L24)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:27](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L27)
 
 ___
 
@@ -178,7 +179,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:31](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L31)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:32](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L32)
 
 ___
 
@@ -188,7 +189,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L15)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:16](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L16)
 
 ___
 
@@ -202,7 +203,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L15)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:16](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L16)
 
 ## Accessors
 
@@ -216,7 +217,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:23](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L23)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L24)
 
 • `set` **additionalScale**(`s`): `void`
 
@@ -232,7 +233,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:19](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L19)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:20](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L20)
 
 ___
 
@@ -250,7 +251,7 @@ KoStageComponent.config
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:37](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L37)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:40](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L40)
 
 • `set` **config**(`c`): `void`
 
@@ -270,7 +271,7 @@ KoStageComponent.config
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:29](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L29)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:32](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L32)
 
 ## Methods
 
@@ -294,7 +295,25 @@ KoStageComponent.config
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:64](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L64)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:72](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L72)
+
+___
+
+### draw
+
+▸ **draw**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[KoStageComponent](KoStageComponent.md).[draw](KoStageComponent.md#draw)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:94](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L94)
 
 ___
 
@@ -312,7 +331,7 @@ AfterContentInit.ngAfterContentInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:54](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L54)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:55](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L55)
 
 ___
 
@@ -330,7 +349,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:56](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L56)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:64](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L64)
 
 ___
 
@@ -352,7 +371,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:58](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L58)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:59](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L59)
 
 ___
 
@@ -374,7 +393,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:50](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L50)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:51](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L51)
 
 ___
 
@@ -388,7 +407,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:63](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L63)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:64](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L64)
 
 ___
 
@@ -402,4 +421,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:67](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L67)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:68](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L68)

--- a/docs/classes/KoStageComponent.md
+++ b/docs/classes/KoStageComponent.md
@@ -26,6 +26,7 @@
 - [afterUpdate](KoStageComponent.md#afterupdate)
 - [beforeUpdate](KoStageComponent.md#beforeupdate)
 - [container](KoStageComponent.md#container)
+- [draw$](KoStageComponent.md#draw$)
 - [onNewLayer](KoStageComponent.md#onnewlayer)
 - [stage](KoStageComponent.md#stage)
 - [sub](KoStageComponent.md#sub)
@@ -37,6 +38,7 @@
 ### Methods
 
 - [addChild](KoStageComponent.md#addchild)
+- [draw](KoStageComponent.md#draw)
 - [ngAfterViewInit](KoStageComponent.md#ngafterviewinit)
 - [ngOnDestroy](KoStageComponent.md#ngondestroy)
 - [ngOnInit](KoStageComponent.md#ngoninit)
@@ -60,7 +62,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:43](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L43)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:46](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L46)
 
 ## Properties
 
@@ -70,7 +72,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:26](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L26)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:29](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L29)
 
 ___
 
@@ -80,7 +82,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L21)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L24)
 
 ___
 
@@ -90,7 +92,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L18)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:21](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L21)
 
 ___
 
@@ -100,7 +102,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:14](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L14)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:15](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L15)
+
+___
+
+### draw$
+
+• `Private` **draw$**: `Subject`\<`void`\>
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:18](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L18)
 
 ___
 
@@ -110,7 +122,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L24)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:27](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L27)
 
 ___
 
@@ -120,7 +132,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L15)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:16](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L16)
 
 ___
 
@@ -130,7 +142,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:41](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L41)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:44](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L44)
 
 ## Accessors
 
@@ -144,7 +156,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:37](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L37)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:40](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L40)
 
 • `set` **config**(`c`): `void`
 
@@ -160,7 +172,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:29](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L29)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:32](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L32)
 
 ## Methods
 
@@ -180,7 +192,21 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:64](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L64)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:72](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L72)
+
+___
+
+### draw
+
+▸ **draw**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:94](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L94)
 
 ___
 
@@ -198,7 +224,7 @@ AfterViewInit.ngAfterViewInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:56](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L56)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:64](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L64)
 
 ___
 
@@ -216,7 +242,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:59](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L59)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:67](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L67)
 
 ___
 
@@ -234,7 +260,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:54](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L54)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:62](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L62)
 
 ___
 
@@ -248,4 +274,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:76](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L76)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:84](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L84)

--- a/docs/classes/KoTouchDirective.md
+++ b/docs/classes/KoTouchDirective.md
@@ -59,7 +59,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:38](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L38)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:43](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L43)
 
 ## Properties
 
@@ -69,7 +69,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:27](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L27)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:32](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L32)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:24](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L24)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:29](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L29)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L18)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:23](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L23)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:15](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L15)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:20](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L20)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:12](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L12)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:17](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L17)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L21)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:26](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L26)
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:29](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L29)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:34](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L34)
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:35](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L35)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:40](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L40)
 
 ___
 
@@ -177,7 +177,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:33](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L33)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:38](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L38)
 
 ___
 
@@ -201,7 +201,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:32](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L32)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:37](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L37)
 
 ___
 
@@ -225,7 +225,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:31](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L31)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:36](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L36)
 
 ___
 
@@ -249,7 +249,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:34](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L34)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:39](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L39)
 
 ___
 
@@ -259,7 +259,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:26](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L26)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:31](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L31)
 
 ## Methods
 
@@ -273,7 +273,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:67](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L67)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:72](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L72)
 
 ___
 
@@ -291,7 +291,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:54](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L54)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:59](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L59)
 
 ___
 
@@ -309,7 +309,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:51](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L51)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:56](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L56)
 
 ___
 
@@ -329,7 +329,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:94](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L94)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:99](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L99)
 
 ___
 
@@ -349,7 +349,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:86](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L86)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:91](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L91)
 
 ___
 
@@ -369,7 +369,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:82](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L82)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:87](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L87)
 
 ___
 
@@ -389,7 +389,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:78](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L78)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:83](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L83)
 
 ___
 
@@ -409,4 +409,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:90](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L90)
+[projects/ngx-konva/src/lib/directives/ko-touch.directive.ts:95](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts#L95)

--- a/docs/classes/KoTransformDirective.md
+++ b/docs/classes/KoTransformDirective.md
@@ -50,7 +50,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:25](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L25)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:30](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L30)
 
 ## Properties
 
@@ -60,7 +60,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:14](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L14)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L19)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:17](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L17)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L22)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:11](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L11)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:16](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L16)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:19](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L19)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:24](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L24)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:23](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L23)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:28](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L28)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:22](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L22)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:27](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L27)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L21)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:26](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L26)
 
 ## Methods
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:46](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L46)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:51](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L51)
 
 ___
 
@@ -194,7 +194,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:39](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L39)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:44](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L44)
 
 ___
 
@@ -212,7 +212,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:36](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L36)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:41](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L41)
 
 ___
 
@@ -232,7 +232,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:60](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L60)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:65](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L65)
 
 ___
 
@@ -252,7 +252,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:56](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L56)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:61](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L61)
 
 ___
 
@@ -272,4 +272,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:52](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L52)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:57](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L57)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -46,7 +46,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:9](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-image.component.ts#L9)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:10](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-image.component.ts#L10)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:11](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L11)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:12](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L12)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:10](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/ko-nestable.ts#L10)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:11](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/ko-nestable.ts#L11)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:21](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/index.ts#L21)
+[projects/ngx-konva/src/lib/common/index.ts:21](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/index.ts#L21)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:17](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/index.ts#L17)
+[projects/ngx-konva/src/lib/common/index.ts:17](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/index.ts#L17)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:18](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/index.ts#L18)
+[projects/ngx-konva/src/lib/common/index.ts:18](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/index.ts#L18)
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:19](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/index.ts#L19)
+[projects/ngx-konva/src/lib/common/index.ts:19](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/index.ts#L19)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:20](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/index.ts#L20)
+[projects/ngx-konva/src/lib/common/index.ts:20](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/index.ts#L20)
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:6](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L6)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:6](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L6)
 
 ## Variables
 
@@ -136,4 +136,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:22](https://github.com/ctinnovation/ngx-konva/blob/8f9d365/projects/ngx-konva/src/lib/common/index.ts#L22)
+[projects/ngx-konva/src/lib/common/index.ts:22](https://github.com/ctinnovation/ngx-konva/blob/f47deef/projects/ngx-konva/src/lib/common/index.ts#L22)

--- a/projects/ngx-konva/src/lib/common/ko-listening.ts
+++ b/projects/ngx-konva/src/lib/common/ko-listening.ts
@@ -1,0 +1,6 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: 'ko-listening',
+})
+export class KoListeningDirective { }

--- a/projects/ngx-konva/src/lib/common/ko-nestable.ts
+++ b/projects/ngx-konva/src/lib/common/ko-nestable.ts
@@ -84,7 +84,6 @@ export class KoNestable implements OnInit, OnDestroy {
       this._tween = undefined;
     }
 
-    console.log(config.listening)
     if (
       this.transitionWith &&
       node.getLayer() &&

--- a/projects/ngx-konva/src/lib/common/ko-nestable.ts
+++ b/projects/ngx-konva/src/lib/common/ko-nestable.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angular/core";
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angular/core";
 import { Group, GroupConfig } from "konva/lib/Group";
 import { Layer, LayerConfig } from "konva/lib/Layer";
 import { Easings, Tween, TweenConfig } from "konva/lib/Tween";
@@ -6,11 +6,15 @@ import { Label, LabelConfig } from "konva/lib/shapes/Label";
 import { Subscription } from "rxjs";
 import { v4 } from "uuid";
 import { KoShape, KoShapeConfig } from ".";
+import { KoListeningDirective } from "./ko-listening";
 
 export type KoNestableNode = Group | Layer | KoShape | Label;
 export type KoNestableConfig = (KoShapeConfig | GroupConfig | LayerConfig | LabelConfig) & { _skipTransition?: boolean };
 
-@Component({ template: '' })
+@Component({
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
 export class KoNestable implements OnInit, OnDestroy {
   static Easings = Easings;
 
@@ -35,15 +39,38 @@ export class KoNestable implements OnInit, OnDestroy {
   protected _tweenTimeout?: any;
   private _initialSetConfig = true;
 
+  protected get shouldListen(): boolean {
+    return !!this.koListening;
+  }
+
+  protected configDefaults: KoShapeConfig = {
+    id: this.id,
+    listening: this.shouldListen,
+    perfectDrawEnabled: false,
+    hitStrokeWidth: 0,
+    shadowForStrokeEnabled: false,
+  }
+
   getKoItem(): KoNestableNode {
     throw new Error('Unimplemented!')
   }
+
+  constructor(
+    protected koListening: KoListeningDirective
+  ) { }
 
   ngOnInit(): void { }
 
   ngOnDestroy(): void {
     this.getKoItem().destroy();
     this.sub.unsubscribe();
+
+
+    if (this._tween) {
+      this._tween.finish();
+      this._tween.destroy();
+      this._tween = undefined;
+    }
   }
 
   setConfig(config: KoNestableConfig) {
@@ -57,6 +84,7 @@ export class KoNestable implements OnInit, OnDestroy {
       this._tween = undefined;
     }
 
+    console.log(config.listening)
     if (
       this.transitionWith &&
       node.getLayer() &&

--- a/projects/ngx-konva/src/lib/components/ko-group.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-group.component.ts
@@ -1,7 +1,9 @@
-import { AfterViewInit, Component, EventEmitter, Input, OnInit, Optional, Output } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Optional, Output, Self } from '@angular/core';
 import { Group } from 'konva/lib/Group';
 import { Layer } from 'konva/lib/Layer';
+import { defaults } from 'lodash';
 import { KoShape } from '../common';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableConfig, KoNestableNode } from '../common/ko-nestable';
 import { KoLayerComponent } from './ko-layer.component';
 
@@ -12,18 +14,16 @@ import { KoLayerComponent } from './ko-layer.component';
   providers: [{
     provide: KoNestable,
     useExisting: KoGroupComponent
-  }]
+  }],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class KoGroupComponent extends KoNestable implements OnInit, AfterViewInit {
   group: Group;
 
-  private _config: KoNestableConfig = {
-    id: this.id
-  };
+  private _config: KoNestableConfig = this.configDefaults;
   @Input()
   set config(c: KoNestableConfig) {
-    this._config = c;
-    this._config.id = this.id;
+    this._config = defaults(c, this.configDefaults);
     this.updateGroup();
   };
 
@@ -37,9 +37,10 @@ export class KoGroupComponent extends KoNestable implements OnInit, AfterViewIni
   afterUpdate = new EventEmitter<Group>();
 
   constructor(
+    @Optional() @Self() override koListening: KoListeningDirective,
     @Optional() private layerComponent: KoLayerComponent
   ) {
-    super();
+    super(koListening);
     this.group = new Group(this._config);
     this.layerComponent.addChild(this.group);
   }

--- a/projects/ngx-konva/src/lib/components/ko-image.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-image.component.ts
@@ -1,6 +1,8 @@
-import { Component, EventEmitter, Input, OnInit, Optional, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Optional, Output, Self } from '@angular/core';
 import { ImageConfig, Image as KonvaImage } from 'konva/lib/shapes/Image';
+import { defaults } from 'lodash';
 import { KoShape } from '../common';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableConfig } from '../common/ko-nestable';
 import { KoGroupComponent } from './ko-group.component';
 import { KoLayerComponent } from './ko-layer.component';
@@ -14,7 +16,8 @@ export type KoImageConfig = Omit<ImageConfig, 'image'>;
   providers: [{
     provide: KoNestable,
     useExisting: KoImageComponent
-  }]
+  }],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class KoImageComponent extends KoNestable implements OnInit {
   node: KonvaImage;
@@ -32,13 +35,11 @@ export class KoImageComponent extends KoNestable implements OnInit {
     this.updateShape();
   };
 
-  private _config: KoNestableConfig = {
-    id: this.id
-  };
+  private _config: KoNestableConfig = this.configDefaults;
   @Input()
   set config(c: KoNestableConfig) {
     this._config = c;
-    this._config['id'] = this.id;
+    this._config = defaults(c, this.configDefaults);
     this.updateShape();
   };
 
@@ -54,6 +55,7 @@ export class KoImageComponent extends KoNestable implements OnInit {
   onLoadListener = this.onImageLoad.bind(this);
 
   constructor(
+    @Optional() @Self() override koListening: KoListeningDirective,
     @Optional() private layerComponent: KoLayerComponent,
     @Optional() private groupComponent: KoGroupComponent
   ) {
@@ -61,7 +63,7 @@ export class KoImageComponent extends KoNestable implements OnInit {
       throw new Error(`ko-image should be nested inside ko-layer!`)
     }
 
-    super();
+    super(koListening);
     this.node = new KonvaImage({
       ...this._config,
       image: this._image

--- a/projects/ngx-konva/src/lib/components/ko-label.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-label.component.ts
@@ -1,7 +1,9 @@
-import { Component, EventEmitter, Input, OnInit, Optional, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Optional, Output, Self } from '@angular/core';
 import { Label, Tag, TagConfig } from 'konva/lib/shapes/Label';
 import { Text, TextConfig } from 'konva/lib/shapes/Text';
+import { defaults } from 'lodash';
 import { v4 } from 'uuid';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableConfig } from '../common/ko-nestable';
 import { KoGroupComponent } from './ko-group.component';
 import { KoLayerComponent } from './ko-layer.component';
@@ -13,20 +15,18 @@ import { KoLayerComponent } from './ko-layer.component';
   providers: [{
     provide: KoNestable,
     useExisting: KoLabelComponent
-  }]
+  }],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class KoLabelComponent extends KoNestable implements OnInit {
   node: Label;
   text?: Text;
   tag?: Tag;
 
-  private _config: KoNestableConfig = {
-    id: this.id
-  };
+  private _config: KoNestableConfig = this.configDefaults;
   @Input()
   set config(c: KoNestableConfig) {
-    this._config = c;
-    this._config.id = this.id;
+    this._config = defaults(c, this.configDefaults);
     this.updateLabel();
   };
 
@@ -74,6 +74,7 @@ export class KoLabelComponent extends KoNestable implements OnInit {
   afterUpdate = new EventEmitter<Label>();
 
   constructor(
+    @Optional() @Self() override koListening: KoListeningDirective,
     @Optional() private layerComponent: KoLayerComponent,
     @Optional() private groupComponent: KoGroupComponent
   ) {
@@ -81,7 +82,7 @@ export class KoLabelComponent extends KoNestable implements OnInit {
       throw new Error(`ko-label should be nested inside ko-layer!`)
     }
 
-    super();
+    super(koListening);
     this.node = new Label(this._config);
     this.text = new Text(this._textConfig);
     this.tag = new Tag(this._tagConfig);

--- a/projects/ngx-konva/src/lib/components/ko-layer.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-layer.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Optional, Output, Self, SkipSelf } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ContentChildren, EventEmitter, Input, OnDestroy, OnInit, Optional, Output, QueryList, Self, SkipSelf } from '@angular/core';
 import { Group } from 'konva/lib/Group';
 import { Layer } from 'konva/lib/Layer';
 import { defaults, isEqual } from 'lodash';
@@ -45,6 +45,15 @@ export class KoLayerComponent extends KoNestable implements OnInit, OnDestroy, A
 
   @Output()
   afterUpdate = new EventEmitter<Layer>();
+
+  @ContentChildren(KoListeningDirective)
+  koListeningChildren!: QueryList<KoListeningDirective>;
+
+  protected override get shouldListen(): boolean {
+    return super.shouldListen ||
+      // if the layer has listening children then the layer should be listening
+      (this.koListeningChildren && this.koListeningChildren.length > 0);
+  }
 
   constructor(
     @Optional() @Self() override koListening: KoListeningDirective,

--- a/projects/ngx-konva/src/lib/components/ko-layer.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-layer.component.ts
@@ -68,7 +68,7 @@ export class KoLayerComponent extends KoNestable implements OnInit, OnDestroy, A
 
     this.sub.add(
       this.draw$
-        .pipe(debounceTime(50))
+        .pipe(debounceTime(10))
         .subscribe(this.draw.bind(this))
     );
   }

--- a/projects/ngx-konva/src/lib/components/ko-layer.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-layer.component.ts
@@ -1,7 +1,10 @@
-import { AfterViewInit, Component, EventEmitter, Input, OnDestroy, OnInit, Optional, Output, SkipSelf } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Optional, Output, Self, SkipSelf } from '@angular/core';
 import { Group } from 'konva/lib/Group';
 import { Layer } from 'konva/lib/Layer';
+import { defaults, isEqual } from 'lodash';
+import { Subject, debounceTime } from 'rxjs';
 import { KoShape } from '../common';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableConfig, KoNestableNode } from '../common/ko-nestable';
 import { KoStageAutoScaleComponent } from './ko-stage-autoscale.component';
 import { KoStageComponent } from './ko-stage.component';
@@ -14,20 +17,23 @@ import { KoStageComponent } from './ko-stage.component';
   providers: [{
     provide: KoNestable,
     useExisting: KoLayerComponent
-  }]
+  }],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class KoLayerComponent extends KoNestable implements OnInit, OnDestroy, AfterViewInit {
   layer: Layer;
   stageComponent: KoStageComponent;
 
-  private _config: KoNestableConfig = {
-    id: this.id
-  };
+  private draw$ = new Subject<void>();
+  private _config: KoNestableConfig = this.configDefaults;
 
   @Input()
   set config(c: KoNestableConfig) {
-    this._config = c;
-    this._config.id = this.id;
+    if (isEqual(c, this._config)) {
+      return;
+    }
+
+    this._config = defaults(c, this.configDefaults);
     this.updateLayer();
   };
 
@@ -41,6 +47,7 @@ export class KoLayerComponent extends KoNestable implements OnInit, OnDestroy, A
   afterUpdate = new EventEmitter<Layer>();
 
   constructor(
+    @Optional() @Self() override koListening: KoListeningDirective,
     @Optional() stageComponent?: KoStageComponent,
     @Optional() stageAutoComponent?: KoStageAutoScaleComponent,
     @Optional() @SkipSelf() private layerComponent?: KoLayerComponent
@@ -49,7 +56,7 @@ export class KoLayerComponent extends KoNestable implements OnInit, OnDestroy, A
       throw new Error('ko-layer should be nested inside ko-stage or ko-stage-autoscale or ko-layer!')
     }
 
-    super();
+    super(koListening);
     this.layer = new Layer(this._config);
     this.stageComponent = (stageComponent || stageAutoComponent)!;
 
@@ -58,6 +65,12 @@ export class KoLayerComponent extends KoNestable implements OnInit, OnDestroy, A
     } else {
       this.stageComponent.addChild(this.layer);
     }
+
+    this.sub.add(
+      this.draw$
+        .pipe(debounceTime(50))
+        .subscribe(this.draw.bind(this))
+    );
   }
 
   override ngOnInit(): void {
@@ -74,7 +87,7 @@ export class KoLayerComponent extends KoNestable implements OnInit, OnDestroy, A
   updateLayer() {
     this.beforeUpdate.emit(this.layer);
     this.setConfig(this._config);
-    this.layer.draw();
+    this.draw$.next();
     this.afterUpdate.emit(this.layer);
   }
 
@@ -87,7 +100,10 @@ export class KoLayerComponent extends KoNestable implements OnInit, OnDestroy, A
     this.layer.add(child);
     this.onNewItem.emit(child);
     child.fire('ko:added', this.layer);
-    this.layer.draw();
+    this.draw$.next();
   }
 
+  draw() {
+    this.layer.draw();
+  }
 }

--- a/projects/ngx-konva/src/lib/components/ko-shape.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-shape.component.ts
@@ -1,5 +1,7 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Optional, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Host, Input, OnInit, Optional, Output } from '@angular/core';
+import { defaults } from 'lodash';
 import { KoShape, KoShapeConfig, KoShapeSelectors, koShapeTypesMap } from '../common';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable } from '../common/ko-nestable';
 import { KoGroupComponent } from './ko-group.component';
 import { KoLayerComponent } from './ko-layer.component';
@@ -11,18 +13,16 @@ import { KoLayerComponent } from './ko-layer.component';
   providers: [{
     provide: KoNestable,
     useExisting: KoShapeComponent
-  }]
+  }],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class KoShapeComponent extends KoNestable implements OnInit {
   shape: KoShape;
 
-  private _config: KoShapeConfig = {
-    id: this.id
-  };
+  private _config: KoShapeConfig = this.configDefaults;
   @Input()
   set config(c: KoShapeConfig) {
-    this._config = c;
-    this._config.id = this.id;
+    this._config = defaults(c, this.configDefaults);
     this.updateShape();
   };
 
@@ -38,11 +38,12 @@ export class KoShapeComponent extends KoNestable implements OnInit {
   selector: KoShapeSelectors;
 
   constructor(
+    @Optional() @Host() override koListening: KoListeningDirective,
     private elementRef: ElementRef<HTMLElement>,
     @Optional() private layerComponent: KoLayerComponent,
     @Optional() private groupComponent: KoGroupComponent
   ) {
-    super();
+    super(koListening);
     this.selector = this.elementRef.nativeElement.localName as KoShapeSelectors;
     if (!layerComponent && !groupComponent) {
       throw new Error(`${this.selector} should be nested inside ko-layer or ko-group!`)

--- a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, SkipSelf } from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, SkipSelf } from '@angular/core';
 import { KoStageComponent } from './ko-stage.component';
 
 @Component({
@@ -8,7 +8,8 @@ import { KoStageComponent } from './ko-stage.component';
   providers: [{
     provide: KoStageComponent,
     useExisting: KoStageAutoScaleComponent
-  }]
+  }],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class KoStageAutoScaleComponent extends KoStageComponent implements OnInit, OnDestroy, AfterContentInit {
   private initialDimensions: { width: number, height: number } | null = null;

--- a/projects/ngx-konva/src/lib/components/ko-stage.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-stage.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Optional, Output } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Optional, Output } from '@angular/core';
 import { Layer } from 'konva/lib/Layer';
 import { Stage, StageConfig } from 'konva/lib/Stage';
 import { Subscription } from 'rxjs';
@@ -8,7 +8,8 @@ export type StageConfigOptionalContainer = Omit<StageConfig, 'container'> & Part
 @Component({
   selector: 'ko-stage',
   template: `<ng-content></ng-content>`,
-  styles: [``]
+  styles: [``],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class KoStageComponent implements OnInit, OnDestroy, AfterViewInit {
   container: ElementRef;

--- a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts
+++ b/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts
@@ -1,10 +1,15 @@
-import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self } from '@angular/core';
+import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self, forwardRef } from '@angular/core';
 import { KonvaEventObject } from 'konva/lib/Node';
 import { KoShape } from '../common';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableNode } from '../common/ko-nestable';
 
 @Directive({
-  selector: '[koDrag]'
+  selector: '[koDrag]',
+  providers: [{
+    provide: KoListeningDirective,
+    useValue: forwardRef(() => KoDragDirective)
+  }],
 })
 export class KoDragDirective implements OnInit, OnDestroy {
   @Output()

--- a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts
+++ b/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts
@@ -1,10 +1,15 @@
-import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self } from '@angular/core';
+import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self, forwardRef } from '@angular/core';
 import { KoShape } from '../common';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableNode } from '../common/ko-nestable';
 
 @Directive({
   selector: '[koHover]',
-  outputs: ['koHoverStart', 'koHoverEnd']
+  outputs: ['koHoverStart', 'koHoverEnd'],
+  providers: [{
+    provide: KoListeningDirective,
+    useValue: forwardRef(() => KoHoverDirective)
+  }],
 })
 export class KoHoverDirective implements OnInit, OnDestroy {
   @Output()

--- a/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts
+++ b/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts
@@ -1,11 +1,16 @@
-import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self } from '@angular/core';
+import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self, forwardRef } from '@angular/core';
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Subscription } from 'rxjs';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableNode } from '../common/ko-nestable';
 import { KoStageComponent } from '../components/ko-stage.component';
 
 @Directive({
-  selector: '[koMouse]'
+  selector: '[koMouse]',
+  providers: [{
+    provide: KoListeningDirective,
+    useValue: forwardRef(() => KoMouseDirective)
+  }],
 })
 export class KoMouseDirective implements OnInit, OnDestroy {
   @Output()

--- a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts
+++ b/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts
@@ -1,11 +1,16 @@
-import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self } from '@angular/core';
+import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self, forwardRef } from '@angular/core';
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Subscription } from 'rxjs';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableNode } from '../common/ko-nestable';
 import { KoStageComponent } from '../components/ko-stage.component';
 
 @Directive({
-  selector: '[koPointer]'
+  selector: '[koPointer]',
+  providers: [{
+    provide: KoListeningDirective,
+    useValue: forwardRef(() => KoPointerDirective)
+  }],
 })
 export class KoPointerDirective implements OnInit, OnDestroy {
   @Output()

--- a/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts
+++ b/projects/ngx-konva/src/lib/directives/ko-touch.directive.ts
@@ -1,11 +1,16 @@
-import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self } from '@angular/core';
+import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self, forwardRef } from '@angular/core';
 import { KonvaEventObject } from 'konva/lib/Node';
 import { Subscription } from 'rxjs';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableNode } from '../common/ko-nestable';
 import { KoStageComponent } from '../components/ko-stage.component';
 
 @Directive({
-  selector: '[koTouch]'
+  selector: '[koTouch]',
+  providers: [{
+    provide: KoListeningDirective,
+    useValue: forwardRef(() => KoTouchDirective)
+  }],
 })
 export class KoTouchDirective implements OnInit, OnDestroy {
   @Output()

--- a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts
+++ b/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts
@@ -1,10 +1,15 @@
-import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self } from '@angular/core';
+import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self, forwardRef } from '@angular/core';
 import { KonvaEventObject } from 'konva/lib/Node';
 import { KoShape } from '../common';
+import { KoListeningDirective } from '../common/ko-listening';
 import { KoNestable, KoNestableNode } from '../common/ko-nestable';
 
 @Directive({
-  selector: '[koTransform]'
+  selector: '[koTransform]',
+  providers: [{
+    provide: KoListeningDirective,
+    useValue: forwardRef(() => KoTransformDirective)
+  }],
 })
 export class KoTransformDirective implements OnInit, OnDestroy {
   @Output()

--- a/unreleased/32.md
+++ b/unreleased/32.md
@@ -1,8 +1,8 @@
 ## Changed
 
-- Core: use `ChangeDetectionStrategy.OnPush` for every library component
+- [breaking] Core: use `ChangeDetectionStrategy.OnPush` for every library component
 - Stage: debounce by 20ms batch drawing 
 - Layer: debounce by 10ms batch drawing 
-- Shape: use `listening: false` as default. When shape is used with a `KoListeningDirective` only then set `listening: true`.
-- Shape: use `shadowForStrokeEnabled: false` and `hitStrokeWidth: 0` as default.
-- Shape: set pixel perfect drawing disabled by default
+- [breaking] Shape: use `listening: false` as default. When shape is used with a `KoListeningDirective` only then set `listening: true`.
+- [breaking] Shape: use `shadowForStrokeEnabled: false` and `hitStrokeWidth: 0` as default.
+- [breaking] Shape: set pixel perfect drawing disabled by default

--- a/unreleased/32.md
+++ b/unreleased/32.md
@@ -1,0 +1,8 @@
+## Changed
+
+- Core: use `ChangeDetectionStrategy.OnPush` for every library component
+- Stage: debounce by 20ms batch drawing 
+- Layer: debounce by 10ms batch drawing 
+- Shape: use `listening: false` as default. When shape is used with a `KoListeningDirective` only then set `listening: true`.
+- Shape: use `shadowForStrokeEnabled: false` and `hitStrokeWidth: 0` as default.
+- Shape: set pixel perfect drawing disabled by default


### PR DESCRIPTION
Reference: #32 

## Changed

- [breaking] Core: use `ChangeDetectionStrategy.OnPush` for every library component
- Stage: debounce by 20ms batch drawing 
- Layer: debounce by 10ms batch drawing 
- [breaking] Shape: use `listening: false` as default. When shape is used with a `KoListeningDirective` only then set `listening: true`.
- [breaking] Shape: use `shadowForStrokeEnabled: false` and `hitStrokeWidth: 0` as default.
- [breaking] Shape: set pixel perfect drawing disabled by default